### PR TITLE
On GCC 7, the <functional> header must be explicitly included

### DIFF
--- a/modules/core/engine/include/AACE/Engine/Core/EngineServiceManager.h
+++ b/modules/core/engine/include/AACE/Engine/Core/EngineServiceManager.h
@@ -16,6 +16,8 @@
 #ifndef AACE_ENGINE_CORE_ENGINE_SERVICE_MANAGER_H
 #define AACE_ENGINE_CORE_ENGINE_SERVICE_MANAGER_H
 
+#include <functional>
+
 #include "EngineService.h"
 
 namespace aace {


### PR DESCRIPTION
The  SDK does not compile with GCC 7 because of a change in Standard Library headers. From the [porting guide](https://www.gnu.org/software/gcc/gcc-7/porting_to.html):

```
Several C++ Standard Library headers have been changed to no longer include
the <functional> header. As such, C++ programs that used components defined
in <functional> without explicitly including that header will no longer compile.
```